### PR TITLE
Increase bump workflow frequency to every 30 minutes

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,7 +1,7 @@
 name: Bump Formulas
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "7,37 * * * *"
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Increase bump formula workflow frequency from every 6 hours to every ~30 minutes
- Offset schedule to :07 and :37 to avoid peak :00/:30 scheduling times

## Test plan
- [ ] CI passes
- [ ] Verify workflow triggers on new schedule via GitHub Actions
