### PR TITLE
Allow brew test commands in Claude Code sandbox

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,8 @@
     "allow": [
       "WebFetch(domain:eu-central-1-1.aws.cloud2.influxdata.com)",
       "WebFetch(domain:index.rubygems.org)",
-      "WebFetch(domain:rubygems.org)"
+      "WebFetch(domain:rubygems.org)",
+      "Bash(brew test *)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary

- Add `Bash(brew test *)` to the Claude Code sandbox allow list so formula tests can run without needing to bypass the sandbox

## Test plan

- [ ] `brew test <formula>` runs without sandbox prompts
