### PR TITLE
Use client-id instead of deprecated app-id for create-github-app-token

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -87,7 +87,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          client-id: ${{ secrets.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## Summary

- Replace deprecated `app-id` input with `client-id` in `actions/create-github-app-token` to resolve the deprecation warning

## Manual step required

The `AUTOMATION_APP_ID` repository secret must be updated to contain the GitHub App's **Client ID** (alphanumeric, found on the app settings page) instead of the numeric App ID.

## Test plan

- [ ] Update the `AUTOMATION_APP_ID` secret with the Client ID value
- [ ] Trigger the bump workflow via `workflow_dispatch`
- [ ] Verify the "Generate App Token" step succeeds without the deprecation warning
- [ ] Verify the downstream PR creation step still works correctly