### PR TITLE
ci: migrate Linux container to ghcr.io/homebrew/ubuntu24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            container: homebrew/ubuntu22.04:master
+            container: ghcr.io/homebrew/ubuntu24.04:main
           - os: macos-latest
     steps:
       - uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
## Summary

- Homebrew now requires glibc > 2.35; Ubuntu 22.04 ships 2.35, causing `brew doctor` to fail in `brew test-bot --only-setup` and blocking all PRs
- Homebrew has also migrated their CI images from Docker Hub to GHCR
- Updates the container to `ghcr.io/homebrew/ubuntu24.04:main` (glibc 2.39), matching what Homebrew's own CI uses

## Test plan

- [ ] Confirm the Linux (`ubuntu-latest`) CI job pulls the container and passes `brew test-bot --only-setup`
- [ ] Confirm formula tests pass on both Linux and macOS