### PR TITLE
ci: update setup-homebrew action from master to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             container: ghcr.io/homebrew/ubuntu24.04:main
           - os: macos-latest
     steps:
-      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: Homebrew/actions/setup-homebrew@main
 
       - run: brew test-bot --only-cleanup-before
 


### PR DESCRIPTION
## Summary
- Updates `Homebrew/actions/setup-homebrew@master` to `@main` in the CI workflow
- The `master` reference is deprecated and will become an error when Homebrew 5.2.0 is released (no earlier than 2026-06-10)

## Test plan
- [ ] Confirm CI workflow runs without the deprecation warning
