### PR TITLE
ci: fix push trigger branch and remove broken dry-run steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 permissions:
   contents: read
@@ -94,12 +94,6 @@ jobs:
 
       - name: Run brew test-bot --only-cleanup-after
         run: brew test-bot --only-cleanup-after
-
-      - name: Run brew test-bot --only-setup --dry-run
-        run: brew test-bot --only-setup --dry-run
-
-      - name: Run brew test-bot --only-formulae --dry-run
-        run: brew test-bot --only-formulae --dry-run --testing-formulae=${{ steps.formulae-detect.outputs.testing_formulae }}
 
   conclusion:
     needs: tests


### PR DESCRIPTION
## Summary

- Fix push trigger targeting `master` instead of `main` — CI was never running on mainline pushes
- Remove two dry-run steps that were producing spurious `##[error] Unexpected bottle JSON/tarball` annotations

## Test plan

- [ ] Verify CI run has no error annotations
- [ ] Verify all three jobs (macOS, Ubuntu, conclusion) pass